### PR TITLE
basic configuration for Travis-CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: d


### PR DESCRIPTION
The repo still needs to be activated on https://travis-ci.org to get tested.
